### PR TITLE
refactor: 채용정보 API 엔드포인트 구조 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,24 +157,37 @@ $ docker-compose -f docker-compose-dev.yml up -d
 
 ### 채용정보 API
 
-- `GET /api/v1/jobs` - 전체 IT 기업 채용정보 조회 (현재 네이버 채용정보만 제공)
+- `GET /api/v1/jobs` - 지원하는 IT 기업 목록 조회
+  - 응답: 지원하는 IT 기업 목록 (현재 네이버, 카카오 지원)
+  - 예시: `curl -X GET "http://localhost:3000/api/v1/jobs"`
+  - 응답 예시:
+  ```json
+  {
+    "companies": [
+      {
+        "code": "NAVER",
+        "name": "네이버"
+      },
+      {
+        "code": "KAKAO",
+        "name": "카카오"
+      }
+    ]
+  }
+  ```
+
+- `GET /api/v1/jobs/:company` - 특정 기업의 채용정보 조회
+  - 파라미터: `company` (기업 ID, 예: NAVER, KAKAO)
   - 쿼리 파라미터:
     - `page`: 페이지 번호 (기본값: 1)
     - `limit`: 페이지당 항목 수 (기본값: 10)
-    - `company`: 회사 필터 (예: NAVER)
-    - `department`: 부서 필터 (예: Tech)
-    - `field`: 분야 필터 (예: Backend, Frontend, AI/ML)
+    - `department`: 부서 필터 (예: Tech, 테크)
+    - `field`: 분야 필터 (예: Backend, Frontend, AI/ML, Server, iOS, Cloud)
     - `career`: 경력 필터 (신입, 경력, 무관)
     - `employmentType`: 고용 형태 필터 (정규, 계약, 인턴)
     - `location`: 위치 필터 (분당, 서울, 춘천 등)
     - `keyword`: 검색어
-  - 예시: `curl -X GET "http://localhost:3000/api/v1/jobs?company=NAVER&field=Backend"`
-  - 기본 응답: 최신순으로 정렬된 채용정보 목록
-
-- `GET /api/v1/jobs/:company` - 특정 기업의 채용정보 조회
-  - 파라미터: `company` (기업 ID, 예: NAVER)
-  - 쿼리 파라미터: 위와 동일 (company 제외)
-  - 예시: `curl -X GET "http://localhost:3000/api/v1/jobs/NAVER?field=AI/ML"`
+  - 예시: `curl -X GET "http://localhost:3000/api/v1/jobs/KAKAO?field=AI/ML"`
   - 기본 응답: 해당 기업의 채용정보 목록
 
 ### 페이지네이션 정보

--- a/src/modules/jobs/dto/requests/get-jobs-query.dto.ts
+++ b/src/modules/jobs/dto/requests/get-jobs-query.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsOptional, IsString } from 'class-validator';
 import {
   CAREER_TYPE,
+  COMPANY_ENUM,
   EMPLOYMENT_TYPE,
   LOCATION_TYPE,
 } from '../../constants/job-codes.constant';
@@ -12,6 +13,11 @@ import {
 } from '../../interfaces/job-posting.interface';
 
 export class GetJobsQueryDto {
+  @ApiProperty({ required: false, enum: COMPANY_ENUM, description: '회사 (예: NAVER, KAKAO)' })
+  @IsEnum(COMPANY_ENUM)
+  @IsOptional()
+  company?: (typeof COMPANY_ENUM)[keyof typeof COMPANY_ENUM];
+
   @ApiProperty({ required: false, description: '부서 (예: Tech)' })
   @IsString()
   @IsOptional()

--- a/src/modules/jobs/dto/responses/supported-companies.response.dto.ts
+++ b/src/modules/jobs/dto/responses/supported-companies.response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CompanyType } from '../../interfaces/job-posting.interface';
+
+export class SupportedCompanyDto {
+  @ApiProperty({ description: '회사 코드' })
+  code: CompanyType;
+
+  @ApiProperty({ description: '회사명' })
+  name: string;
+}
+
+export class SupportedCompaniesResponseDto {
+  @ApiProperty({ description: '지원하는 회사 목록', type: [SupportedCompanyDto] })
+  companies: SupportedCompanyDto[];
+} 

--- a/src/modules/jobs/jobs.controller.ts
+++ b/src/modules/jobs/jobs.controller.ts
@@ -3,6 +3,7 @@ import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { JobsService, PaginatedResponse } from './services/jobs.service';
 import { GetJobsQueryDto } from './dto/requests/get-jobs-query.dto';
 import { JobPostingResponseDto } from './dto/responses/job-posting.response.dto';
+import { SupportedCompaniesResponseDto } from './dto/responses/supported-companies.response.dto';
 import { CompanyType } from './interfaces/job-posting.interface';
 
 @ApiTags('jobs')
@@ -11,17 +12,14 @@ export class JobsController {
   constructor(private readonly jobsService: JobsService) {}
 
   @Get()
-  @ApiOperation({ summary: '전체 기술 직군 채용 정보 조회' })
+  @ApiOperation({ summary: '지원하는 회사 목록 조회' })
   @ApiResponse({
     status: 200,
-    description: '기술 직군 채용 정보 목록',
-    type: JobPostingResponseDto,
-    isArray: true,
+    description: '지원하는 회사 목록',
+    type: SupportedCompaniesResponseDto,
   })
-  async getTechJobs(
-    @Query() query: GetJobsQueryDto,
-  ): Promise<PaginatedResponse<JobPostingResponseDto>> {
-    return this.jobsService.getTechJobs(query);
+  async getSupportedCompanies(): Promise<SupportedCompaniesResponseDto> {
+    return this.jobsService.getSupportedCompanies();
   }
 
   @Get(':company')

--- a/src/modules/redis/redis.service.ts
+++ b/src/modules/redis/redis.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { Redis } from 'ioredis';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class RedisService {
   private readonly redis: Redis;
+  private readonly logger = new Logger(RedisService.name);
 
   constructor(private readonly configService: ConfigService) {
     this.redis = new Redis({
@@ -30,5 +31,41 @@ export class RedisService {
 
   async del(key: string): Promise<void> {
     await this.redis.del(key);
+  }
+
+  async flushAll(): Promise<void> {
+    await this.redis.flushall();
+  }
+
+  /**
+   * 특정 패턴의 키들만 초기화
+   * @param pattern Redis 키 패턴 (예: 'jobs:*')
+   */
+  async flushByPattern(pattern: string): Promise<void> {
+    try {
+      const keys = await this.redis.keys(pattern);
+      if (keys.length > 0) {
+        await this.redis.del(...keys);
+        this.logger.log(`Cleared ${keys.length} keys matching pattern: ${pattern}`);
+      }
+    } catch (error) {
+      this.logger.error(`Failed to flush keys by pattern ${pattern}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * 서비스 시작 시 캐시 초기화
+   * @param serviceName 서비스 이름 (예: 'jobs', 'notices')
+   */
+  async initializeServiceCache(serviceName: string): Promise<void> {
+    try {
+      const pattern = `${serviceName}:*`;
+      await this.flushByPattern(pattern);
+      this.logger.log(`Initialized cache for service: ${serviceName}`);
+    } catch (error) {
+      this.logger.error(`Failed to initialize cache for service ${serviceName}:`, error);
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
- GET /api/v1/jobs 엔드포인트를 지원하는 회사 목록만 반환하도록 변경
- GET /api/v1/jobs/:company 엔드포인트에서 특정 회사의 채용정보 조회
- README.md API 문서 업데이트

현재 지원하는 회사:
- 네이버
- 카카오