### PR TITLE
feat(jobs): 당근마켓 채용정보 크롤러 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   - 무신사, 네이버 D2, 토스, 뱅크샐러드, 긱뉴스
   - 메타, 넷플릭스, 구글, 아마존, 마켓컬리, 카카오엔터프라이즈
 - 주요 IT 기업 채용정보 조회
-  - 네이버, 카카오, 라인, 쿠팡, 우아한형제들
+  - 네이버, 카카오, 라인, 쿠팡, 우아한형제들, 당근마켓
 - API 서비스 상태 모니터링 (health check)
 
 ## 개발 환경
@@ -158,7 +158,7 @@ $ docker-compose -f docker-compose-dev.yml up -d
 ### 채용정보 API
 
 - `GET /api/v1/jobs` - 지원하는 IT 기업 목록 조회
-  - 응답: 지원하는 IT 기업 목록 (현재 네이버, 카카오, 라인, 쿠팡, 우아한형제들 지원)
+  - 응답: 지원하는 IT 기업 목록 (현재 네이버, 카카오, 라인, 쿠팡, 우아한형제들, 당근마켓 지원)
   - 예시: `curl -X GET "http://localhost:3000/api/v1/jobs"`
   - 응답 예시:
   ```json
@@ -183,13 +183,17 @@ $ docker-compose -f docker-compose-dev.yml up -d
       {
         "code": "BAEMIN",
         "name": "BAEMIN"
+      },
+      {
+        "code": "DANGGN",
+        "name": "DANGGN"
       }
     ]
   }
   ```
 
 - `GET /api/v1/jobs/{company}` - 특정 기업의 채용정보 조회
-  - 파라미터: `company` (기업 ID, 예: NAVER, KAKAO, LINE, COUPANG, BAEMIN)
+  - 파라미터: `company` (기업 ID, 예: NAVER, KAKAO, LINE, COUPANG, BAEMIN, DANGGN)
   - 쿼리 파라미터:
     - `page`: 페이지 번호 (기본값: 1)
     - `limit`: 페이지당 항목 수 (기본값: 10)
@@ -199,7 +203,7 @@ $ docker-compose -f docker-compose-dev.yml up -d
     - `employmentType`: 고용 형태 필터 (정규, 계약, 인턴)
     - `location`: 위치 필터 (분당, 서울, 춘천, 글로벌 등)
     - `keyword`: 검색어
-  - 예시: `curl -X GET "http://localhost:3000/api/v1/jobs/LINE?field=AI/ML"`
+  - 예시: `curl -X GET "http://localhost:3000/api/v1/jobs/DANGGN?field=Backend"`
   - 기본 응답: 해당 기업의 채용정보 목록
 
 ### 페이지네이션 정보
@@ -403,10 +407,6 @@ modules/[module-name]/
 
 HanbatTechHub(테크누리)는 한밭대학교 모바일융합공학과와 와이소프트 학생들을 위한 프로젝트로 시작되었으며, 추후 다양한 IT 관련 소식을 통합 제공할 예정입니다.
 
-향후 계획:
-- 추가 IT 기업의 채용정보 크롤링 기능 (현재 네이버, 카카오, 라인, 쿠팡, 우아한형제들 지원)
-- 사용자 관심 분야별 맞춤 알림 기능
-- 모바일 앱 지원
 
 ## 라이센스
 

--- a/src/modules/jobs/constants/job-codes.constant.ts
+++ b/src/modules/jobs/constants/job-codes.constant.ts
@@ -44,6 +44,7 @@ export const COMPANY_ENUM = {
   LINE: 'LINE',
   COUPANG: 'COUPANG',
   BAEMIN: 'BAEMIN',
+  DANGGN: 'DANGGN',
 } as const;
 
 export const EMPLOYMENT_TYPE = {

--- a/src/modules/jobs/crawlers/danggn.crawler.ts
+++ b/src/modules/jobs/crawlers/danggn.crawler.ts
@@ -1,0 +1,197 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { BaseJobCrawler } from './base-job.crawler';
+import { GetJobsQueryDto } from '../dto/requests/get-jobs-query.dto';
+import { JobPosting } from '../interfaces/job-posting.interface';
+import {
+  COMPANY_ENUM,
+  CAREER_TYPE,
+  EMPLOYMENT_TYPE,
+  LOCATION_TYPE,
+} from '../constants/job-codes.constant';
+import { HttpClientUtil } from '../utils/http-client.util';
+import * as cheerio from 'cheerio';
+
+@Injectable()
+export class DanggnCrawler extends BaseJobCrawler {
+  protected readonly logger = new Logger(DanggnCrawler.name);
+  public readonly baseUrl = 'https://about.daangn.com/jobs';
+
+  constructor(
+    protected readonly httpClient: HttpClientUtil,
+    protected readonly configService: ConfigService,
+  ) {
+    super(COMPANY_ENUM.DANGGN, httpClient, 'https://about.daangn.com/jobs');
+  }
+
+  async fetchJobs(_query?: GetJobsQueryDto): Promise<JobPosting[]> {
+    this.logger.debug('Starting to fetch Danggn jobs...');
+
+    try {
+      const url = this.buildUrl(_query);
+      this.logger.debug(`Fetching jobs from: ${url}`);
+
+      const response = await this.httpClient.get(url, {
+        headers: {
+          Accept:
+            'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+          'Accept-Language': 'ko-KR,ko;q=0.8,en-US;q=0.5,en;q=0.3',
+          'User-Agent': this.httpClient.getRandomUserAgent(),
+          'Cache-Control': 'no-cache',
+          Pragma: 'no-cache',
+        },
+      });
+
+      if (!response || typeof response !== 'string') {
+        throw new Error('Invalid response data');
+      }
+
+      this.logger.debug('Response received, length:', response.length);
+
+      // HTML 파싱
+      const jobs = this.parseJobListings(response);
+
+      if (jobs.length === 0) {
+        this.logger.warn('No jobs found in the parsed HTML');
+      } else {
+        this.logger.debug(`Successfully parsed ${jobs.length} jobs`);
+      }
+
+      return jobs;
+    } catch (error) {
+      this.handleError('Failed to fetch Danggn jobs', error);
+      return [];
+    }
+  }
+
+  private buildUrl(_query?: GetJobsQueryDto): string {
+    return this.baseUrl;
+  }
+
+  private parseJobListings(html: string): JobPosting[] {
+    try {
+      const $ = cheerio.load(html);
+      const jobs: JobPosting[] = [];
+
+      $('.c-deAcZv').each((_, element) => {
+        const $el = $(element);
+        const title = $el.find('.c-boyXyq').text().trim();
+        const employmentType = $el.find('.c-kolfYf').last().text().trim();
+        const url = $el.find('a').attr('href');
+
+        // IT 직군 필터링
+        if (
+          title.includes('Software Engineer') ||
+          title.includes('Security Engineer') ||
+          title.includes('Site Reliability Engineer') ||
+          title.includes('Test Automation Engineer') ||
+          title.includes('Application Security Engineer') ||
+          title.includes('Information Security Manager')
+        ) {
+          const jobId = url?.split('/').filter(Boolean).pop() || '';
+          const jobUrl = url ? `${this.baseUrl}${url}` : this.baseUrl;
+          const job: JobPosting = {
+            id: jobId,
+            company: this.company,
+            title,
+            department: this.extractDepartment(title),
+            field: this.extractField(title),
+            requirements: {
+              career: CAREER_TYPE.ANY,
+              skills: this.extractSkills(title),
+            },
+            employmentType: this.mapEmploymentType(employmentType),
+            locations: [LOCATION_TYPE.SEOUL],
+            period: {
+              start: new Date(),
+              end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30일 후
+            },
+            url: jobUrl,
+            source: {
+              originalId: jobId,
+              originalUrl: jobUrl,
+            },
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            tags: [],
+            jobCategory: this.extractJobCategory(title),
+          };
+
+          jobs.push(job);
+        }
+      });
+
+      return jobs;
+    } catch (err) {
+      this.handleError('Failed to parse job listings', err);
+      return [];
+    }
+  }
+
+  private extractDepartment(title: string): string {
+    if (title.includes('당근페이')) {
+      return '당근페이';
+    }
+    return '당근';
+  }
+
+  private extractField(title: string): string {
+    if (title.includes('Frontend')) return 'Frontend';
+    if (title.includes('Backend')) return 'Backend';
+    if (title.includes('Android')) return 'Android';
+    if (title.includes('iOS')) return 'iOS';
+    if (title.includes('Security')) return 'Security';
+    if (title.includes('Site Reliability')) return 'Infrastructure';
+    if (title.includes('Test Automation')) return 'QA';
+    if (title.includes('Data')) return 'Data';
+    if (title.includes('Machine Learning')) return 'ML';
+    return 'Engineering';
+  }
+
+  private extractSkills(title: string): string[] {
+    const skills: string[] = [];
+    if (title.includes('Kotlin')) skills.push('Kotlin');
+    if (title.includes('Android')) skills.push('Android');
+    if (title.includes('iOS')) skills.push('iOS');
+    if (title.includes('Frontend')) skills.push('Frontend');
+    if (title.includes('Backend')) skills.push('Backend');
+    if (title.includes('Security')) skills.push('Security');
+    if (title.includes('Site Reliability')) skills.push('Infrastructure');
+    if (title.includes('Test Automation')) skills.push('QA');
+    if (title.includes('Data')) skills.push('Data');
+    if (title.includes('Machine Learning')) skills.push('ML');
+    return skills;
+  }
+
+  private mapEmploymentType(
+    type: string,
+  ): (typeof EMPLOYMENT_TYPE)[keyof typeof EMPLOYMENT_TYPE] {
+    switch (type) {
+      case '정규직':
+        return EMPLOYMENT_TYPE.FULL_TIME;
+      case '계약직':
+        return EMPLOYMENT_TYPE.CONTRACT;
+      case '인턴':
+        return EMPLOYMENT_TYPE.INTERN;
+      default:
+        return EMPLOYMENT_TYPE.FULL_TIME;
+    }
+  }
+
+  private extractJobCategory(title: string): string {
+    if (title.includes('Frontend')) return 'Frontend';
+    if (title.includes('Backend')) return 'Backend';
+    if (title.includes('Android')) return 'Mobile';
+    if (title.includes('iOS')) return 'Mobile';
+    if (title.includes('Security')) return 'Security';
+    if (title.includes('Site Reliability')) return 'Infrastructure';
+    if (title.includes('Test Automation')) return 'QA';
+    if (title.includes('Data')) return 'Data';
+    if (title.includes('Machine Learning')) return 'ML';
+    return 'Engineering';
+  }
+
+  getJobDetailUrl(jobId: string): string {
+    return `${this.baseUrl}/${jobId}`;
+  }
+}

--- a/src/modules/jobs/crawlers/index.ts
+++ b/src/modules/jobs/crawlers/index.ts
@@ -7,6 +7,7 @@ import { CoupangCrawler } from './coupang.crawler';
 import { BaeminCrawler } from './baemin.crawler';
 import { HttpClientUtil } from '../utils/http-client.util';
 import { ConfigService } from '@nestjs/config';
+import { DanggnCrawler } from './danggn.crawler';
 
 export const CRAWLER_TOKEN = 'CRAWLER_TOKEN';
 
@@ -17,6 +18,7 @@ const crawlerClasses = [
   LineCrawler,
   CoupangCrawler,
   BaeminCrawler,
+  DanggnCrawler,
   // KakaoTechCrawler,
   // WoowabrosCrawler,
   // 추가 크롤러 클래스들...
@@ -44,12 +46,14 @@ export const createCrawlers = (
     new LineCrawler(httpClient, configService),
     new CoupangCrawler(httpClient, configService),
     new BaeminCrawler(httpClient, configService),
+    new DanggnCrawler(httpClient, configService),
   ];
 };
 
-export * from './naver.crawler';
 export * from './base-job.crawler';
-export * from './example.crawler';
+export * from './naver.crawler';
+export * from './kakao.crawler';
 export * from './line.crawler';
 export * from './coupang.crawler';
 export * from './baemin.crawler';
+export * from './danggn.crawler';

--- a/src/modules/jobs/services/jobs.service.ts
+++ b/src/modules/jobs/services/jobs.service.ts
@@ -19,7 +19,6 @@ import {
   JOBS_UPDATE_CRON,
   JOB_CRAWLING_CONFIG,
 } from '../constants/redis.constant';
-import { COMPANY_ENUM } from '../constants/job-codes.constant';
 
 export interface PaginatedResponse<T> {
   data: T[];


### PR DESCRIPTION
- 당근마켓 채용정보 크롤러 구현
  - BaseJobCrawler를 상속받아 DanggnCrawler 클래스 구현
  - 당근마켓 채용 페이지에서 IT 직군 채용정보 수집
  - 채용정보 필터링 및 데이터 정규화 로직 구현

- COMPANY_ENUM에 DANGGN 추가
  - 당근마켓을 지원 기업 목록에 추가
  - 기존 크롤러들의 동작에 영향 없음

- README.md 업데이트
  - 당근마켓을 지원 기업 목록에 추가
  - API 응답 예시에 당근마켓 정보 추가
  - API 문서 업데이트

- 기타 변경사항
  - 불필요한 변수 제거로 린트 경고 해결
  - 코드 스타일 정리